### PR TITLE
Feat: Trunk based deployment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,48 @@ Automatically moves a tag to the `HEAD` of the current branch if it finds the ta
 - automatically update the `dev` tag to the `HEAD` of `develop` when the branch it's on is merged
 - automatically update the `qa` tag to the `HEAD` of `develop` when a new branch is merged into it
 
+NOTE: You will want to make sure you checkout with `fetch-depth: 0` to get the git history needed to run the operations. Otherwise the refs wont be there for `rev-list` to output and for us to use to detect the tag in the history.
+
+Example usage:
+
+```yaml
+name: Automated retagging
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+
+  # Updates the dev tag to the HEAD of develop if it's merged, which then if
+  # changed, re-triggers the automated deployment.
+  retag-dev-to-head:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: paperkite/github-actions/retag-to-head@main
+        with:
+          tag: dev
+          branch: develop
+
+  # Updates the qa tag to the HEAD of develop if it's merged, which then if
+  # changed, re-triggers the automated deployment.
+  retag-qa-to-head:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: paperkite/github-actions/retag-to-head@main
+        with:
+          tag: qa
+          branch: develop
+
+```
+
 ## Workflows
 
 None so far

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This handles the whole process of creating the source ZIP and it's files, the ve
 - Creating the EB application version
 - Deploying the EB application version to one or many EB environments
 
+### `retag-to-head`
+
+Automatically moves a tag to the `HEAD` of the current branch if it finds the tag in the history of the current branch. This is used to:
+
+- automatically update the `dev` tag to the `HEAD` of `develop` when the branch it's on is merged
+- automatically update the `qa` tag to the `HEAD` of `develop` when a new branch is merged into it
+
 ## Workflows
 
 None so far

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This handles the whole process of creating the source ZIP and it's files, the ve
 - Creating the EB application version
 - Deploying the EB application version to one or many EB environments
 
-### `retag-to-head`
+### `move-tag-to-head-if-merged`
 
 Automatically moves a tag to the `HEAD` of the current branch if it finds the tag in the history of the current branch. This is used to:
 
@@ -49,26 +49,28 @@ jobs:
 
   # Updates the dev tag to the HEAD of develop if it's merged, which then if
   # changed, re-triggers the automated deployment.
-  retag-dev-to-head:
+  move-dev-tag-to-head-if-merged:
+    name: Move dev tag to develop HEAD if merged
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: paperkite/github-actions/retag-to-head@main
+      - uses: paperkite/github-actions/move-tag-to-head-if-merged@main
         with:
           tag: dev
           branch: develop
 
   # Updates the qa tag to the HEAD of develop if it's merged, which then if
   # changed, re-triggers the automated deployment.
-  retag-qa-to-head:
+  move-qa-tag-to-head-if-merged:
+    name: Move qa tag to develop HEAD if merged
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: paperkite/github-actions/retag-to-head@main
+      - uses: paperkite/github-actions/move-tag-to-head-if-merged@main
         with:
           tag: qa
           branch: develop

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -42,7 +42,7 @@ runs:
   using: composite
   steps:
 
-    - uses: paperkite/github-actions/generate-sha@feat/trunk-based-deployment-flow
+    - uses: paperkite/github-actions/generate-sha@main
       id: generate-sha
 
     - name: Evaluate environment

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -1,5 +1,6 @@
 name: Generate environment info
 description: Evaluates the workflows running context and determines the environment that is being built
+
 inputs:
   eb-environment-names-dev:
     required: false
@@ -16,6 +17,7 @@ inputs:
   eb-environment-names-production:
     required: false
     description: A comma seperated value of the Production EB Environments
+
 outputs:
   name:
     description: The human name of the environment
@@ -35,51 +37,79 @@ outputs:
   eb-environment-names:
     description: A comma-sepearted-value of the EB Environment names
     value: ${{ steps.evaluate-workflow.outputs.eb-environment-names }}
+
 runs:
   using: composite
   steps:
+
     - uses: paperkite/github-actions/generate-sha@main
       id: generate-sha
-    - name: Evaluate workflow
-      id: evaluate-workflow
+
+    - name: Evaluate environment
+      id: evaluate-environment
       shell: bash
       run: |
         echo "GITHUB_REF_TYPE = $GITHUB_REF_TYPE"
         echo "GITHUB_REF_NAME = $GITHUB_REF_NAME"
-        if [ $GITHUB_REF_TYPE == "branch" ]; then
-          if [ $GITHUB_REF_NAME == "dev" ]; then
-            echo "::set-output name=name::development"
-            echo "::set-output name=prefix::dev"
-            echo "::set-output name=version::dev-${{ steps.generate-sha.outputs.sha }}"
-            echo "::set-output name=rails-env::dev"
-            echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-dev }}"
-          elif [ $GITHUB_REF_NAME == "qa" ]; then
-            echo "::set-output name=name::QA"
-            echo "::set-output name=prefix::qa"
-            echo "::set-output name=version::qa-${{ steps.generate-sha.outputs.sha }}"
-            echo "::set-output name=rails-env::qa"
-            echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-qa }}"
-          elif [ $GITHUB_REF_NAME == "uat" ]; then
-            echo "::set-output name=name::UAT"
-            echo "::set-output name=prefix::uat"
-            echo "::set-output name=version::uat-${{ steps.generate-sha.outputs.sha }}"
-            echo "::set-output name=rails-env::uat"
-            echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-uat }}"
-          elif [ $GITHUB_REF_NAME == "staging" ]; then
-            echo "::set-output name=name::staging"
-            echo "::set-output name=prefix::staging"
-            echo "::set-output name=version::staging-${{ steps.generate-sha.outputs.sha }}"
-            echo "::set-output name=rails-env::staging"
-            echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-staging }}"
-          else
-            exit 1
-          fi
-        elif [ $GITHUB_REF_TYPE == "tag" ]; then
+
+        branch_or_tag_regex="^(branch|tag)$"
+        # matches
+        semmantic_commit_regex="^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$"
+
+        if [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "dev" ]; then
+          environment=dev
+        elif [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]; then
+          environment=qa
+        elif [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]; then
+          environment=uat
+        elif [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]; then
+          environment=staging
+        elif [ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "staging" ]; then
+          environment=staging
+        else
+          echo "Failed to evaluate environment: unexpected ref type ($GITHUB_REF_TYPE) and name ($GITHUB_REF_NAME)"
+          exit 1
+        fi
+
+        echo "::set-output name=environment::$environment"
+
+    - name: Output environment info
+      id: output-environment-info
+      shell: bash
+      run: |
+        environment=${{ steps.evaluate-environment.outputs.environment }}
+
+        if [ environment == "dev" ]; then
+          echo "::set-output name=name::development"
+          echo "::set-output name=prefix::dev"
+          echo "::set-output name=version::dev-${{ steps.generate-sha.outputs.sha }}"
+          echo "::set-output name=rails-env::dev"
+          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-dev }}"
+        elif [ environment == "qa" ]; then
+          echo "::set-output name=name::QA"
+          echo "::set-output name=prefix::qa"
+          echo "::set-output name=version::qa-${{ steps.generate-sha.outputs.sha }}"
+          echo "::set-output name=rails-env::qa"
+          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-qa }}"
+        elif [ environment == "uat" ]; then
+          echo "::set-output name=name::UAT"
+          echo "::set-output name=prefix::uat"
+          echo "::set-output name=version::uat-${{ steps.generate-sha.outputs.sha }}"
+          echo "::set-output name=rails-env::uat"
+          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-uat }}"
+        elif [ environment == "staging" ]; then
+          echo "::set-output name=name::staging"
+          echo "::set-output name=prefix::staging"
+          echo "::set-output name=version::staging-${{ steps.generate-sha.outputs.sha }}"
+          echo "::set-output name=rails-env::staging"
+          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-staging }}"
+        elif [ environment == "production" ]; then
           echo "::set-output name=name::production"
           echo "::set-output name=prefix::prod"
           echo "::set-output name=version::$GITHUB_REF_NAME"
           echo "::set-output name=rails-env::production"
           echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-production }}"
         else
+          echo "Failed to set ouputs: unexpected environment ($environment)"
           exit 1
         fi

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -56,15 +56,15 @@ runs:
         # matches
         semmantic_commit_regex="^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$"
 
-        if [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "dev" ]; then
+        if [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "dev" ]]; then
           environment=dev
-        elif [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]; then
+        elif [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]]; then
           environment=qa
-        elif [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]; then
+        elif [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]]; then
           environment=uat
-        elif [ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]; then
+        elif [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]]; then
           environment=staging
-        elif [ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "staging" ]; then
+        elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "staging" ]]; then
           environment=staging
         else
           echo "Failed to evaluate environment: unexpected ref type ($GITHUB_REF_TYPE) and name ($GITHUB_REF_NAME)"
@@ -79,31 +79,31 @@ runs:
       run: |
         environment=${{ steps.evaluate-environment.outputs.environment }}
 
-        if [ environment == "dev" ]; then
+        if [[ environment == "dev" ]]; then
           echo "::set-output name=name::development"
           echo "::set-output name=prefix::dev"
           echo "::set-output name=version::dev-${{ steps.generate-sha.outputs.sha }}"
           echo "::set-output name=rails-env::dev"
           echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-dev }}"
-        elif [ environment == "qa" ]; then
+        elif [[ environment == "qa" ]]; then
           echo "::set-output name=name::QA"
           echo "::set-output name=prefix::qa"
           echo "::set-output name=version::qa-${{ steps.generate-sha.outputs.sha }}"
           echo "::set-output name=rails-env::qa"
           echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-qa }}"
-        elif [ environment == "uat" ]; then
+        elif [[ environment == "uat" ]]; then
           echo "::set-output name=name::UAT"
           echo "::set-output name=prefix::uat"
           echo "::set-output name=version::uat-${{ steps.generate-sha.outputs.sha }}"
           echo "::set-output name=rails-env::uat"
           echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-uat }}"
-        elif [ environment == "staging" ]; then
+        elif [[ environment == "staging" ]]; then
           echo "::set-output name=name::staging"
           echo "::set-output name=prefix::staging"
           echo "::set-output name=version::staging-${{ steps.generate-sha.outputs.sha }}"
           echo "::set-output name=rails-env::staging"
           echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-staging }}"
-        elif [ environment == "production" ]; then
+        elif [[ environment == "production" ]]; then
           echo "::set-output name=name::production"
           echo "::set-output name=prefix::prod"
           echo "::set-output name=version::$GITHUB_REF_NAME"

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -64,8 +64,8 @@ runs:
           environment=uat
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]]; then
           environment=staging
-        elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "staging" ]]; then
-          environment=staging
+        elif [[ $GITHUB_REF_TYPE =~ $semmantic_commit_regex ]]; then
+          environment=production
         else
           echo "Failed to evaluate environment: unexpected ref type ($GITHUB_REF_TYPE) and name ($GITHUB_REF_NAME)"
           exit 1

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -64,7 +64,7 @@ runs:
           environment=uat
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]]; then
           environment=staging
-        elif [[ $GITHUB_REF_TYPE =~ $semmantic_commit_regex ]]; then
+        elif [[ $GITHUB_REF_TYPE =~ $semmantic_commit_regex ]]; then # TODO: fix
           environment=production
         else
           echo "Failed to evaluate environment: unexpected ref type ($GITHUB_REF_TYPE) and name ($GITHUB_REF_NAME)"

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -56,13 +56,13 @@ runs:
         # matches
         semmantic_commit_regex="^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$"
 
-        if [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "dev" ]]; then
+        if [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "dev" ]]; then
           environment=dev
-        elif [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]]; then
+        elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]]; then
           environment=qa
-        elif [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]]; then
+        elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]]; then
           environment=uat
-        elif [[ $GITHUB_REF_TYPE =~ branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]]; then
+        elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "staging" ]]; then
           environment=staging
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "staging" ]]; then
           environment=staging

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -21,28 +21,28 @@ inputs:
 outputs:
   name:
     description: The human name of the environment
-    value: ${{ steps.evaluate-workflow.outputs.name }}
+    value: ${{ steps.output-environment-info.outputs.NAME }}
   prefix:
     description: The environment prefix used for EB environments, image tagging, etc
-    value: ${{ steps.evaluate-workflow.outputs.prefix }}
+    value: ${{ steps.output-environment-info.outputs.PREFIX }}
   version:
     description: The version name used for EB versions (the tag version or the prefixed SHA)
-    value: ${{ steps.evaluate-workflow.outputs.version }}
+    value: ${{ steps.output-environment-info.outputs.VERSION }}
   rails-env:
     description: The RAILS_ENV to use for the environment
-    value: ${{ steps.evaluate-workflow.outputs.rails-env }}
+    value: ${{ steps.output-environment-info.outputs.RAILS_ENV }}
   sha:
     description: The corresponding Git commits SHA
-    value: ${{ steps.generate-sha.outputs.sha }}
+    value: ${{ steps.generate-sha.outputs.SHA }}
   eb-environment-names:
     description: A comma-sepearted-value of the EB Environment names
-    value: ${{ steps.evaluate-workflow.outputs.eb-environment-names }}
+    value: ${{ steps.output-environment-info.outputs.EB_ENVIRONMENT_NAMES }}
 
 runs:
   using: composite
   steps:
 
-    - uses: paperkite/github-actions/generate-sha@main
+    - uses: paperkite/github-actions/generate-sha@feat/trunk-based-deployment-flow
       id: generate-sha
 
     - name: Evaluate environment
@@ -71,44 +71,44 @@ runs:
           exit 1
         fi
 
-        echo "::set-output name=environment::$environment"
+        echo "ENVIRONMENT=$environment" >> $GITHUB_OUTPUT
 
     - name: Output environment info
       id: output-environment-info
       shell: bash
       run: |
-        environment=${{ steps.evaluate-environment.outputs.environment }}
+        environment=${{ steps.evaluate-environment.outputs.ENVIRONMENT }}
 
-        if [[ environment == "dev" ]]; then
-          echo "::set-output name=name::development"
-          echo "::set-output name=prefix::dev"
-          echo "::set-output name=version::dev-${{ steps.generate-sha.outputs.sha }}"
-          echo "::set-output name=rails-env::dev"
-          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-dev }}"
-        elif [[ environment == "qa" ]]; then
-          echo "::set-output name=name::QA"
-          echo "::set-output name=prefix::qa"
-          echo "::set-output name=version::qa-${{ steps.generate-sha.outputs.sha }}"
-          echo "::set-output name=rails-env::qa"
-          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-qa }}"
-        elif [[ environment == "uat" ]]; then
-          echo "::set-output name=name::UAT"
-          echo "::set-output name=prefix::uat"
-          echo "::set-output name=version::uat-${{ steps.generate-sha.outputs.sha }}"
-          echo "::set-output name=rails-env::uat"
-          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-uat }}"
-        elif [[ environment == "staging" ]]; then
-          echo "::set-output name=name::staging"
-          echo "::set-output name=prefix::staging"
-          echo "::set-output name=version::staging-${{ steps.generate-sha.outputs.sha }}"
-          echo "::set-output name=rails-env::staging"
-          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-staging }}"
-        elif [[ environment == "production" ]]; then
-          echo "::set-output name=name::production"
-          echo "::set-output name=prefix::prod"
-          echo "::set-output name=version::$GITHUB_REF_NAME"
-          echo "::set-output name=rails-env::production"
-          echo "::set-output name=eb-environment-names::${{ inputs.eb-environment-names-production }}"
+        if [[ $environment == "dev" ]]; then
+          echo "NAME=development" >> $GITHUB_OUTPUT
+          echo "PREFIX=dev" >> $GITHUB_OUTPUT
+          echo "VERSION=dev-${{ steps.generate-sha.outputs.sha }}" >> $GITHUB_OUTPUT
+          echo "RAILS_ENV=dev" >> $GITHUB_OUTPUT
+          echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-dev }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "qa" ]]; then
+          echo "NAME=QA" >> $GITHUB_OUTPUT
+          echo "PREFIX=qa" >> $GITHUB_OUTPUT
+          echo "VERSION=qa-${{ steps.generate-sha.outputs.sha }}" >> $GITHUB_OUTPUT
+          echo "RAILS_ENV=qa" >> $GITHUB_OUTPUT
+          echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-qa }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "uat" ]]; then
+          echo "NAME=UAT" >> $GITHUB_OUTPUT
+          echo "PREFIX=uat" >> $GITHUB_OUTPUT
+          echo "VERSION=uat-${{ steps.generate-sha.outputs.sha }}" >> $GITHUB_OUTPUT
+          echo "RAILS_ENV=uat" >> $GITHUB_OUTPUT
+          echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-uat }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "staging" ]]; then
+          echo "NAME=staging" >> $GITHUB_OUTPUT
+          echo "PREFIX=staging" >> $GITHUB_OUTPUT
+          echo "VERSION=staging-${{ steps.generate-sha.outputs.sha }}" >> $GITHUB_OUTPUT
+          echo "RAILS_ENV=staging" >> $GITHUB_OUTPUT
+          echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-staging }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "production" ]]; then
+          echo "NAME=production" >> $GITHUB_OUTPUT
+          echo "PREFIX=prod" >> $GITHUB_OUTPUT
+          echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          echo "RAILS_ENV=production" >> $GITHUB_OUTPUT
+          echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-production }}" >> $GITHUB_OUTPUT
         else
           echo "Failed to set ouputs: unexpected environment ($environment)"
           exit 1

--- a/generate-sha/action.yml
+++ b/generate-sha/action.yml
@@ -1,13 +1,16 @@
 name: Generate SHA
 description: Creates a consitent SHA from the commits for our docker images
+
 outputs:
   sha:
     description: The generated SHA to be used for image tagging etc
-    value: ${{ steps.generate-sha.outputs.sha }}
+    value: ${{ steps.generate-sha.outputs.SHA }}
+
 runs:
   using: composite
   steps:
     - name: Generate SHA
       id: generate-sha
       shell: bash
-      run: echo "::set-output name=sha::$(git rev-parse --short=8 HEAD)"
+      run: |
+        echo "SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT

--- a/move-tag-to-head-if-merged/action.yaml
+++ b/move-tag-to-head-if-merged/action.yaml
@@ -1,5 +1,5 @@
-name: Retag to HEAD
-description: Checks if a tag is in history and retags it to the HEAD
+name: Move tag to HEAD if merged
+description: Checks if a tag has been merged into a branched history and if so, retags it to the HEAD
 
 inputs:
   tag:
@@ -14,7 +14,7 @@ runs:
   steps:
 
     - name: Check branch history for tag
-      id: check-for-tag
+      id: check-if-merged
       shell: bash
       run: |
         tag_sha=$(git rev-list -n 1 "${{ inputs.tag }}")
@@ -29,7 +29,7 @@ runs:
         fi
 
     - name: Retag to HEAD
-      if: steps.check-for-tag.outputs.RETAG == 'true'
+      if: steps.check-if-merged.outputs.RETAG == 'true'
       shell: bash
       run: |
         git tag --force ${{ inputs.tag }}

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -21,10 +21,10 @@ runs:
         head_sha=$(git rev-list -n 1 "${{ inputs.branch }}")
 
         if [[ git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep $tag_sha ]]; then
-          echo "Found tag in history of ${{ inputs.branch }}, retag to HEAD."
+          echo "Found tag ($tag_sha) in history of ${{ inputs.branch }}, retag to HEAD ($head_sha)."
           echo "RETAG=true" >> $GITHUB_OUTPUT
         else
-          echo "Tag not found in history of ${{ inputs.branch }}, not retagging to HEAD."
+          echo "Tag ($tag_sha) not found in history of ${{ inputs.branch }}, don't retag to HEAD ($head_sha)."
           echo "RETAG=false" >> $GITHUB_OUTPUT
         fi
 

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -20,7 +20,7 @@ runs:
         tag_sha=$(git rev-list -n 1 "${{ inputs.tag }}")
         head_sha=$(git rev-list -n 1 "${{ inputs.branch }}")
 
-        if [[ git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep -q $tag_sha ]]; then
+        if git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep -q $tag_sha; then
           echo "Found tag ($tag_sha) in history of ${{ inputs.branch }}, retag to HEAD ($head_sha)."
           echo "RETAG=true" >> $GITHUB_OUTPUT
         else

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -20,7 +20,7 @@ runs:
         tag_sha=$(git rev-list -n 1 "${{ inputs.tag }}")
         head_sha=$(git rev-list -n 1 "${{ inputs.branch }}")
 
-        if git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep -q $tag_sha; then
+        if git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep $tag_sha; then
           echo "Found tag ($tag_sha) in history of ${{ inputs.branch }}, retag to HEAD ($head_sha)."
           echo "RETAG=true" >> $GITHUB_OUTPUT
         else

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -1,0 +1,33 @@
+name: Retag to HEAD
+description: Checks if a tag is in history and retags it to the HEAD
+
+inputs:
+  tag:
+    required: true
+    description: The tag we are checking for and retagging HEAD with
+  branch:
+    required: true
+    description: The branch we are checking against
+
+runs:
+  using: composite
+  steps:
+
+    - name: Check branch history for tag
+      id: check-for-tag
+      shell: bash
+      run: |
+        if [ git rev-list ${{ inputs.branch }} | grep $(git rev-list -n 1 "dev") ]; then
+          echo "Found tag in history of ${{ inputs.branch }}, retag to HEAD."
+          echo "RETAG=true" >> $GITHUB_OUTPUT
+        else
+          echo "Tag not found in history of ${{ inputs.branch }}, not retagging to HEAD."
+          echo "RETAG=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Retag to HEAD
+      if: steps.check-for-tag.outputs.RETAG == true
+      shell: bash
+      run: |
+        git tag --force ${{ inputs.tag }}
+        git push --tags --force

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -20,7 +20,7 @@ runs:
         tag_sha=$(git rev-list -n 1 "${{ inputs.tag }}")
         head_sha=$(git rev-list -n 1 "${{ inputs.branch }}")
 
-        if [[ git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep $tag_sha ]]; then
+        if [[ git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep -q $tag_sha ]]; then
           echo "Found tag ($tag_sha) in history of ${{ inputs.branch }}, retag to HEAD ($head_sha)."
           echo "RETAG=true" >> $GITHUB_OUTPUT
         else

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -29,7 +29,7 @@ runs:
         fi
 
     - name: Retag to HEAD
-      if: steps.check-for-tag.outputs.RETAG == true
+      if: steps.check-for-tag.outputs.RETAG == 'true'
       shell: bash
       run: |
         git tag --force ${{ inputs.tag }}

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -17,7 +17,7 @@ runs:
       id: check-for-tag
       shell: bash
       run: |
-        if [ git rev-list ${{ inputs.branch }} | grep $(git rev-list -n 1 "dev") ]; then
+        if [[ git rev-list ${{ inputs.branch }} | grep $(git rev-list -n 1 "dev") ]]; then
           echo "Found tag in history of ${{ inputs.branch }}, retag to HEAD."
           echo "RETAG=true" >> $GITHUB_OUTPUT
         else

--- a/retag-to-head/action.yaml
+++ b/retag-to-head/action.yaml
@@ -17,7 +17,10 @@ runs:
       id: check-for-tag
       shell: bash
       run: |
-        if [[ git rev-list ${{ inputs.branch }} | grep $(git rev-list -n 1 "dev") ]]; then
+        tag_sha=$(git rev-list -n 1 "${{ inputs.tag }}")
+        head_sha=$(git rev-list -n 1 "${{ inputs.branch }}")
+
+        if [[ git rev-list ${{ inputs.branch }} | grep -v $head_sha | grep $tag_sha ]]; then
           echo "Found tag in history of ${{ inputs.branch }}, retag to HEAD."
           echo "RETAG=true" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
### 📝 Description

<!--- Link the JIRA issue if it exists -->

<!--- Describe the details and explain the reason you did that way -->

This will enable continuous deployment and management of the environments when accompanied with automated re-tagging as develop is updated. The aim is to remove the frustration caused by using the dev/qa branches and make our internal environments a representation of the trunk by default.

You can see how this is being used with the first implementation using it on BPPlus:

- https://github.com/paperkite/bpau-bpme-api/pull/309


#### Automated deployment usage

Here's an example automated deployment workflow:

- https://github.com/paperkite/bpau-bpme-api/actions/runs/3464869416

![image](https://user-images.githubusercontent.com/15931780/201761509-bafb7413-a93c-4bc9-a93c-512204840986.png)


#### Automated retagging usage

I have tested the automated retagging when it needs to retag, but I can't find my workflow run. I can reverify it but it's a little bit of playing around to do so without it merged. Here's an example of the automated retagging wasn't needed (it's not in history):

- https://github.com/paperkite/bpau-bpme-api/actions/runs/3464860395

![image](https://user-images.githubusercontent.com/15931780/201761626-fb9a5ed0-a777-4800-bb22-24a1180a3cbc.png)


<!--- Attach screenshots to help reviewers understand easily -->