### PR TITLE
Feat: Action to validate OAS schemas have been bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ jobs:
 
 ```
 
+### `check-oas-bundled`
+
+This action just checks if the provided source schema is bundled in the target directory and that it's been checked in verison control. This is primarily to prevent drift from people not comitting the schemas and also the RSpec OAS validation happens against the bundled schema, which means uncomittted bundled schemas can break tests on later PRs.
+
+```yaml
+jobs:
+
+  check_api_oas_bundled:
+    name: Check API OAS is bundled
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: paperkite/github-actions/check-oas-bundled
+        with:
+          schema: ./docs/api/build/schema.yaml
+          source: ./docs/api/schema.yaml
+```
+
 ## Workflows
 
 None so far

--- a/check-oas-bundled/action.yaml
+++ b/check-oas-bundled/action.yaml
@@ -1,15 +1,15 @@
-name: Validate OAS schemas
+name: Check OAS schema is bundled
 description: >-
-  Validates if the OAS schema file has been bundled (there are no changes) and
-  that the bundled schema has no errors
+  Checks if the OAS schema file has been bundled from the source to prevent any
+  drifting in the bundled schema and it's source folder
 
 inputs:
-  schema:
+  bundled_schema:
     required: true
-    description: The schema file to validate
-  source:
+    description: The bundled schema file
+  source_schema:
     required: true
-    description: The source folder to validate against the schema
+    description: The source file that is the root of the schema
 
 runs:
   using: composite
@@ -46,8 +46,3 @@ runs:
           echo "Schema (${{ inputs.schema }}) has been bundled"
           exit 0
         fi
-
-    - name: Validate schema
-      shell: bash
-      run: |
-        swagger-cli validate ${{ inputs.schema }}

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -24,6 +24,12 @@ runs:
     - name: Check if schema has been bundled
       shell: bash
       run: |
+        echo "Bundling schema"
+        swagger-cli bundle ${{ inputs.source }} --outfile ${{ inputs.schema }} --type yaml
+
+        echo "Checking if there's changes"
+        git diff --name-only --diff-filter=dr HEAD | cat
+
         if git diff --name-only --diff-filter=dr HEAD | grep ${{ inputs.schema }}; then
           echo "Schema (${{ inputs.schema }}) has been bundled"
           exit 0

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -28,9 +28,16 @@ runs:
           echo "Schema (${{ inputs.schema }}) has been bundled"
           exit 0
         else
-          echo "Schema (${{ inputs.schema }}) has not been bundled"
-          echo "Please run the following command and commit the bundled schema:"
-          echo "  swagger-cli bundle ${{ inputs.source }} --outfile ${{ inputs.schema }} --type yaml"
+          cat <<- EOF
+        Schema (${{ inputs.schema }}) has not been bundled
+
+        Please run the following command and commit the bundled schema:
+          swagger-cli bundle ${{ inputs.source }} --outfile ${{ inputs.schema }} --type yaml
+
+        Diff:
+
+        $(git diff HEAD ${{ inputs.schema }} | cat)
+        EOF
           exit 1
         fi
 

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get yarn
-        yarn global add swagger-cli
+        yarn global add @apidevtools/swagger-cli
 
     - name: Check if schema has been bundled
       shell: bash

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -18,7 +18,7 @@ runs:
     - name: Install swagger-cli
       shell: bash
       run: |
-        sudo apt-get yarn
+        sudo apt-get install yarn
         yarn global add @apidevtools/swagger-cli
 
     - name: Check if schema has been bundled

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -31,9 +31,6 @@ runs:
         git diff --name-only --diff-filter=dr HEAD | cat
 
         if git diff --name-only --diff-filter=dr HEAD | grep ${{ inputs.schema }}; then
-          echo "Schema (${{ inputs.schema }}) has been bundled"
-          exit 0
-        else
           cat <<- EOF
         Schema (${{ inputs.schema }}) has not been bundled
 
@@ -45,6 +42,9 @@ runs:
         $(git diff HEAD ${{ inputs.schema }} | cat)
         EOF
           exit 1
+        else
+          echo "Schema (${{ inputs.schema }}) has been bundled"
+          exit 0
         fi
 
     - name: Validate schema

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -1,0 +1,40 @@
+name: Validate OAS schemas
+description: >-
+  Validates if the OAS schema file has been bundled (there are no changes) and
+  that the bundled schema has no errors
+
+inputs:
+  schema:
+    required: true
+    description: The schema file to validate
+  source:
+    required: true
+    description: The source folder to validate against the schema
+
+runs:
+  using: composite
+  steps:
+
+    - name: Install swagger-cli
+      shell: bash
+      run: |
+        sudo apt-get yarn
+        yarn global add swagger-cli
+
+    - name: Check if schema has been bundled
+      shell: bash
+      run: |
+        if git diff --name-only --diff-filter=dr ${{ github.event.pull_request.base.sha }}..${{ github.sha }} | grep ${{ inputs.schema }}; then
+          echo "Schema (${{ inputs.schema }}) has been bundled"
+          exit 0
+        else
+          echo "Schema (${{ inputs.schema }}) has not been bundled"
+          echo "Please run the following command and commit the bundled schema:"
+          echo "  swagger-cli bundle ${{ inputs.source }} --outfile ${{ inputs.schema }} --type yaml"
+          exit 1
+        fi
+
+    - name: Validate schema
+      shell: bash
+      run: |
+        swagger-cli validate ${{ inputs.schema }}

--- a/validate-oas/action.yaml
+++ b/validate-oas/action.yaml
@@ -24,7 +24,7 @@ runs:
     - name: Check if schema has been bundled
       shell: bash
       run: |
-        if git diff --name-only --diff-filter=dr ${{ github.event.pull_request.base.sha }}..${{ github.sha }} | grep ${{ inputs.schema }}; then
+        if git diff --name-only --diff-filter=dr HEAD | grep ${{ inputs.schema }}; then
           echo "Schema (${{ inputs.schema }}) has been bundled"
           exit 0
         else


### PR DESCRIPTION
<!--
  This is the development/hotfix template, if doing a release or update PR, use the different
  templates from in Confluence:
  https://paperkite.atlassian.net/wiki/spaces/PWAP/pages/2370928641
-->


### 📝 Description
<!-- Describe the PR & explain the reason -->

This is a CI action used for checking the OAS has been bundled. It was going to contain the validation as well but then I realised OAS validation is strangely disparate. Instead I opted us to using [char0n/swagger-editor-validate](https://github.com/char0n/swagger-editor-validate) to validate it against the `swaggerapi/swagger-editor` docker image. This requires running via `services` which then means it must be written in the workflow. This makes sense. See the related PR for how this is used together in one workflow.


### 🌳 Related PRs
<!-- List related PRs below or remove section if not used -->

- https://github.com/paperkite/bp-bpme-api/pull/1735
