### PR TITLE
Fix: fix broken inputs in check-oas-bundled after rename

### DIFF
--- a/check-oas-bundled/action.yaml
+++ b/check-oas-bundled/action.yaml
@@ -25,24 +25,24 @@ runs:
       shell: bash
       run: |
         echo "Bundling schema"
-        swagger-cli bundle ${{ inputs.source }} --outfile ${{ inputs.schema }} --type yaml
+        swagger-cli bundle ${{ inputs.source_schema }} --outfile ${{ inputs.bundled_schema }} --type yaml
 
         echo "Checking if there's changes"
         git diff --name-only --diff-filter=dr HEAD | cat
 
-        if git diff --name-only --diff-filter=dr HEAD | grep ${{ inputs.schema }}; then
+        if git diff --name-only --diff-filter=dr HEAD | grep ${{ inputs.bundled_schema }}; then
           cat <<- EOF
-        Schema (${{ inputs.schema }}) has not been bundled
+        Schema (${{ inputs.bundled_schema }}) has not been bundled
 
         Please run the following command and commit the bundled schema:
-          swagger-cli bundle ${{ inputs.source }} --outfile ${{ inputs.schema }} --type yaml
+          swagger-cli bundle ${{ inputs.source_schema }} --outfile ${{ inputs.bundled_schema }} --type yaml
 
         Diff:
 
-        $(git diff HEAD ${{ inputs.schema }} | cat)
+        $(git diff HEAD ${{ inputs.bundled_schema }} | cat)
         EOF
           exit 1
         else
-          echo "Schema (${{ inputs.schema }}) has been bundled"
+          echo "Schema (${{ inputs.bundled_schema }}) has been bundled"
           exit 0
         fi


### PR DESCRIPTION
<!--
  This is the development/hotfix template, if doing a release or update PR, use the different
  templates from in Confluence:
  https://paperkite.atlassian.net/wiki/spaces/PWAP/pages/2370928641
-->
<!-- Update this with the JIRA ticket link -->
🎫 [BPME-6436](https://paperkite.atlassian.net/browse/BPME-6436)


### 📝 Description
<!-- Describe the PR & explain the reason -->

Correcting an issue w/ the inputs as I renamed them but didn't realise I broke them as the action passes when the files don't exist interestingly.


### 🌳 Related PRs
<!-- List related PRs below or remove section if not used -->

- #10 
- https://github.com/paperkite/bp-bpme-api/pull/1735
- https://github.com/paperkite/bp-bpme-api/pull/1726


[BPME-6436]: https://paperkite.atlassian.net/browse/BPME-6436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ