### PR TITLE
Fix: point new-staging logic to staging to fix generate-environment-info

### DIFF
--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -132,7 +132,7 @@ runs:
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "internal-rc" ]]; then
           environment=internal
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME =~ $staging_semmantic_version_regex ]]; then
-          environment=new-staging
+          environment=staging
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]]; then
           environment=qa
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]]; then


### PR DESCRIPTION
### 📝 Description
<!-- Describe the PR & explain the reason -->

I broke the "new" staging logic when I removed the `new-staging` output setup and just merged it with `staging` but didn't correct the `evaluate-environment` job that was still outputting `new-staging`.

This was done like this when we had two ways of doing staging but it's fine at this stage to just have two flows that are considered "staging" even if they are often done slightly differently it should be fine.


### 🌳 Related PRs
<!-- List related PRs below or remove section if not used -->

- https://github.com/paperkite/bpme-uber-driver-service/pull/57
- #12 (where I broke this)
