### PR TITLE
Fix: revert removal of new-staging flow in generate-environment-ino

### DIFF
--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -132,7 +132,7 @@ runs:
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "internal-rc" ]]; then
           environment=internal
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME =~ $staging_semmantic_version_regex ]]; then
-          environment=staging
+          environment=new-staging
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]]; then
           environment=qa
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]]; then
@@ -195,6 +195,15 @@ runs:
           echo "PREFIX=staging" >> $GITHUB_OUTPUT
           echo "VERSION=staging-${{ steps.generate-sha.outputs.sha }}" >> $GITHUB_OUTPUT
           echo "RAILS_ENV=staging" >> $GITHUB_OUTPUT
+          echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-staging }}" >> $GITHUB_OUTPUT
+          echo "ECS_CLUSTER_NAME=${{ inputs.ecs-cluster-name-staging }}" >> $GITHUB_OUTPUT
+          echo "ECS_SERVICE_NAME=${{ inputs.ecs-service-name-staging }}" >> $GITHUB_OUTPUT
+          echo "ECS_TD_FAMILY=${{ inputs.ecs-td-family-staging }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "new-staging" ]]; then
+          echo "NAME=staging" >> $GITHUB_OUTPUT
+          echo "PREFIX=staging" >> $GITHUB_OUTPUT
+          echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          echo "RAILS_ENV=qa" >> $GITHUB_OUTPUT
           echo "EB_ENVIRONMENT_NAMES=${{ inputs.eb-environment-names-staging }}" >> $GITHUB_OUTPUT
           echo "ECS_CLUSTER_NAME=${{ inputs.ecs-cluster-name-staging }}" >> $GITHUB_OUTPUT
           echo "ECS_SERVICE_NAME=${{ inputs.ecs-service-name-staging }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### 📝 Description
<!-- Describe the PR & explain the reason -->

I'm dumb, this was necessary. The old staging setups have staging everything, rails env, DB etc, the new-staging semi-maps to QA.

I broke the "new" staging logic (v1.0.2-staging-rc.1 etc) when I removed the `new-staging` output setup and just merged it with `staging` but didn't correct the `evaluate-environment` job that was still outputting `new-staging`. So I pointed the "new" staging logic to old `staging` flow and it broke further.


### 🌳 Related PRs
<!-- List related PRs below or remove section if not used -->

- #13 (where I broke it further)
- https://github.com/paperkite/bpme-uber-driver-service/pull/57
- #12 (where I broke this)
