### PR TITLE
feat: add configure-aws-credentials action

### DIFF
--- a/configure-aws-credentials/action.yml
+++ b/configure-aws-credentials/action.yml
@@ -1,0 +1,72 @@
+name: Configure AWS credentials
+description: Configures AWS credentials for the workflow
+
+inputs:
+  env:
+    required: true
+    description: The environment to configure AWS credentials for
+  internal-aws-ecr-url:
+    required: false
+    description: The internal AWS ECR URL
+  internal-aws-access-key-id:
+    required: false
+    description: The internal AWS access key ID
+  internal-aws-secret-access-key:
+    required: false
+    description: The internal AWS secret access key
+  staging-aws-ecr-url:
+    required: false
+    description: The staging AWS ECR URL
+  staging-aws-access-key-id:
+    required: false
+    description: The staging AWS access key ID
+  staging-aws-secret-access-key:
+    required: false
+    description: The staging AWS secret access key
+  production-aws-ecr-url:
+    required: false
+    description: The production AWS ECR URL
+  production-aws-access-key-id:
+    required: false
+    description: The production AWS access key ID
+  production-aws-secret-access-key:
+    required: false
+    description: The production AWS secret access key
+
+outputs:
+  ecr-url:
+    description: The AWS ECR URL to use
+    value: ${{ steps.configure-aws-credentials.outputs.ecr-url }}
+  access-key:
+    description: The AWS access key ID to use
+    value: ${{ steps.configure-aws-credentials.outputs.access-key }}
+  secret-access-key:
+    description: The AWS access key secret
+    value: ${{ steps.configure-aws-credentials.outputs.secret-access-key }}
+
+runs:
+  using: composite
+  steps:
+
+    - name: Output environment info
+      id: output-environment-info
+      shell: bash
+      run: |
+        environment=${{ inputs.env }}
+
+        if [[ $environment == "internal" ]]; then
+          echo "ECR_URL=${{ inputs.internal-aws-ecr-url }}" >> $GITHUB_OUTPUT
+          echo "ACCESS_KEY=${{ inputs.internal-aws-access-key-id }}" >> $GITHUB_OUTPUT
+          echo "SECRET_ACCESS_KEY=${{ inputs.internal-aws-secret-access-key }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "staging" ]]; then
+          echo "ECR_URL=${{ inputs.staging-aws-ecr-url }}" >> $GITHUB_OUTPUT
+          echo "ACCESS_KEY=${{ inputs.staging-aws-access-key-id }}" >> $GITHUB_OUTPUT
+          echo "SECRET_ACCESS_KEY=${{ inputs.staging-aws-secret-access-key }}" >> $GITHUB_OUTPUT
+        elif [[ $environment == "production" ]]; then
+          echo "ECR_URL=${{ inputs.production-aws-ecr-url }}" >> $GITHUB_OUTPUT
+          echo "ACCESS_KEY=${{ inputs.production-aws-access-key-id }}" >> $GITHUB_OUTPUT
+          echo "SECRET_ACCESS_KEY=${{ inputs.production-aws-secret-access-key }}" >> $GITHUB_OUTPUT
+        else
+          echo "Failed to set ouputs: unexpected environment ($environment)"
+          exit 1
+        fi

--- a/configure-aws-credentials/action.yml
+++ b/configure-aws-credentials/action.yml
@@ -36,18 +36,17 @@ inputs:
 outputs:
   ecr-url:
     description: The AWS ECR URL to use
-    value: ${{ steps.configure-aws-credentials.outputs.ecr-url }}
+    value: ${{ steps.output-environment-info.outputs.ECR_URL }}
   access-key:
     description: The AWS access key ID to use
-    value: ${{ steps.configure-aws-credentials.outputs.access-key }}
+    value: ${{ steps.output-environment-info.outputs.ACCESS_KEY }}
   secret-access-key:
     description: The AWS access key secret
-    value: ${{ steps.configure-aws-credentials.outputs.secret-access-key }}
+    value: ${{ steps.output-environment-info.outputs.SECRET_ACCESS_KEY }}
 
 runs:
   using: composite
   steps:
-
     - name: Output environment info
       id: output-environment-info
       shell: bash

--- a/configure-aws-credentials/action.yml
+++ b/configure-aws-credentials/action.yml
@@ -69,3 +69,14 @@ runs:
           echo "Failed to set ouputs: unexpected environment ($environment)"
           exit 1
         fi
+    - name: Debug environment info
+      shell: bash
+      run: |
+        echo "inputs ECR URL: ${{ inputs.staging-aws-ecr-url }}"
+        echo "inputs AWS Access Key ID: ${{ inputs.staging-aws-access-key-id }}"
+        echo "inputs AWS Secret Access Key: ${{ inputs.staging-aws-secret-access-key }}"
+        echo "env: ${{ inputs.env }}"
+        echo "ECR_URL: ${{ steps.output-environment-info.outputs.ECR_URL }}"
+        echo "ACCESS_KEY: ${{ steps.output-environment-info.outputs.ACCESS_KEY }}"
+        echo "SECRET_ACCESS_KEY: ${{ steps.output-environment-info.outputs.SECRET_ACCESS_KEY }}"
+      

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -135,7 +135,7 @@ runs:
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME == "internal-rc" ]]; then
           environment=internal
         elif [[ $GITHUB_REF_TYPE == "tag" && $GITHUB_REF_NAME =~ $staging_semmantic_version_regex ]]; then
-          environment=new-staging
+          environment=staging
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "qa" ]]; then
           environment=qa
         elif [[ $GITHUB_REF_TYPE =~ $branch_or_tag_regex && $GITHUB_REF_NAME == "uat" ]]; then

--- a/generate-environment-info/action.yml
+++ b/generate-environment-info/action.yml
@@ -231,3 +231,4 @@ runs:
           echo "Failed to set ouputs: unexpected environment ($environment)"
           exit 1
         fi
+


### PR DESCRIPTION
Added `configure-aws-credentials` action so that we can deploy to different AWS accounts per env.
I've just added another action so that existing projects which have already used this github action with single AWS account doesn't actually need to change anything.

See:  https://github.com/paperkite/mpi-fishing/pull/6