### PR TITLE
fix: drop runtimePlatform from task definition JSON when null

### DIFF
--- a/deploy-ecs-crons/action.yml
+++ b/deploy-ecs-crons/action.yml
@@ -69,8 +69,10 @@ runs:
           --arg image_url ${{ inputs.ecr-image-url }} \
           '.containerDefinitions[0].image = $image_url')
         
-        # Filter the task definition JSON down to the CLI input values
-        new_td_cli_json=$(echo $new_td_json | jq '{ family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, runtimePlatform }')
+        # Filter the task definition JSON down to the CLI input values.
+        # runtimePlatform is only valid as an object; register-task-definition rejects an explicit
+        # null (e.g. for EC2 launch type tasks), so drop the key entirely when it's null.
+        new_td_cli_json=$(echo $new_td_json | jq '{ family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, runtimePlatform } | if .runtimePlatform == null then del(.runtimePlatform) else . end')
         
         # Validate the JSON is not empty
         if [ "$(echo $new_td_cli_json | jq -r '.family')" = "null" ]; then

--- a/deploy-ecs-service/action.yml
+++ b/deploy-ecs-service/action.yml
@@ -74,8 +74,10 @@ runs:
           --arg image_url ${{ inputs.ecr-image-url }} \
           '.containerDefinitions[0].image = $image_url')
         
-        # Filter the task definition JSON down to the CLI input values
-        new_td_cli_json=$(echo $new_td_json | jq '{ family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, runtimePlatform }')
+        # Filter the task definition JSON down to the CLI input values.
+        # runtimePlatform is only valid as an object; register-task-definition rejects an explicit
+        # null (e.g. for EC2 launch type tasks), so drop the key entirely when it's null.
+        new_td_cli_json=$(echo $new_td_json | jq '{ family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, runtimePlatform } | if .runtimePlatform == null then del(.runtimePlatform) else . end')
         
         # Validate the JSON is not empty
         if [ "$(echo $new_td_cli_json | jq -r '.family')" = "null" ]; then

--- a/deploy-ecs-task/action.yml
+++ b/deploy-ecs-task/action.yml
@@ -49,10 +49,13 @@ runs:
           exit 1
         fi
 
+        # runtimePlatform is only valid as an object; register-task-definition rejects an explicit
+        # null (e.g. for EC2 launch type tasks), so drop the key entirely when it's null.
         new_td_cli_json=$(echo $latest_td_json | jq \
           --arg image_url "${{ inputs.ecr-image-url }}" \
           '.containerDefinitions[0].image = $image_url
-          | { family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, runtimePlatform }')
+          | { family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, runtimePlatform }
+          | if .runtimePlatform == null then del(.runtimePlatform) else . end')
 
         if [ "$(echo $new_td_cli_json | jq -r '.family')" = "null" ]; then
           echo "Error: Generated task definition JSON is invalid"


### PR DESCRIPTION
## Summary
- register-task-definition rejects an explicit null for runtimePlatform, even though omitting the key entirely is valid
- EC2 launch-type tasks (e.g. bridge network mode) legitimately have a null runtimePlatform, so the fix in 54aa7c2 that started forwarding it broke deploys for any EC2-based service using deploy-ecs-service, deploy-ecs-crons, or deploy-ecs-task
- This drops the key only when it's null, preserving it as-is for Fargate tasks where it's a real object (the original intent of 54aa7c2)

Root cause surfaced via a failed dmd-internal deploy in dmd-platform — see the register-task-definition ParamValidation error: Invalid type for parameter runtimePlatform, value: None.

## Test plan
- [x] Verified locally with jq that a null runtimePlatform gets dropped and a real object is preserved
- [ ] Re-run the dmd-internal deploy workflow once this is merged and referenced, confirm register-task-definition succeeds
- [ ] Spot-check a Fargate-based service's next deploy to confirm runtimePlatform still carries through unchanged